### PR TITLE
Fix a compile error emitting from io/formatting.hpp

### DIFF
--- a/VTIL-Common/io/formatting.hpp
+++ b/VTIL-Common/io/formatting.hpp
@@ -27,6 +27,7 @@
 //
 #pragma once
 #include <string>
+#include <cstring>
 #include <type_traits>
 #include "../util/concept.hpp"
 #include "../util/lt_typeid.hpp"


### PR DESCRIPTION
This fixes an issue where current attempts at compiling the project produces the following error message:
```VTIL-Core/VTIL-Common/includes/vtil/../../math/../util/../io/formatting.hpp:119:55: error: ‘strlen’ was not declared in this scope
  119 |       in = in.substr( 0, i + 1 ) + in.substr( i + 1 + strlen( str ) );
      |                                                       ^~~~~~```