### PR TITLE
Fix D9025 and C26451 warnings

### DIFF
--- a/VTIL-Common/VTIL-Common.vcxproj
+++ b/VTIL-Common/VTIL-Common.vcxproj
@@ -61,7 +61,8 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
-      <SDLCheck>true</SDLCheck>
+      <SDLCheck>
+      </SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>

--- a/VTIL-Common/io/formatting.hpp
+++ b/VTIL-Common/io/formatting.hpp
@@ -117,8 +117,8 @@ namespace vtil::format
 					return fix_type_name( in.substr( strlen( str ) ) );
 				for ( int i = 0; i < in.size(); i++ )
 				{
-					if ( in[ i ] == '<' && in.substr( i + 1 ).starts_with( str ) )
-						in = in.substr( 0, i + 1 ) + in.substr( i + 1 + strlen( str ) );
+					if ( in[ i ] == '<' && in.substr( size_t( i ) + 1 ).starts_with( str ) )
+						in = in.substr( 0, size_t( i ) + 1 ) + in.substr( size_t( i ) + 1 + strlen( str ) );
 				}
 			}
 			return in;


### PR DESCRIPTION
Warnings are quite annoying.

Disclaimer, I haven't really checked if casting `i` to architecture size_t has any side-effects.