### PR TITLE
Modernize compiler flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: cpp
 
-compiler:
-  - clang
-
 os: linux
 dist: bionic
 
@@ -20,10 +17,6 @@ before_script:
   # Install latest LLVM from LLVM repository
   - sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
   - sudo DEBIAN_FRONTEND=noninteractive apt-get -yq install libc++-10-dev libc++abi-10-dev
-
-  # Setup env variables to use Clang 10
-  - CC=/usr/bin/clang-10
-  - CCX=/usr/bin/clang++-10
 
   # Run CMake generator
   - /usr/bin/cmake --version # print so we can see which version travis is using

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,38 +9,6 @@ option(VTIL_BUILD_TESTS "Build tests" OFF)
 # Append the CMake module search path so we can use our own modules
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
-# For portability on non-MSVC compilers, add some compile options
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
-    add_compile_options(-Wno-narrowing)
-	add_compile_options(-Wno-format-security)
-	add_compile_options(-Wno-unused-value)
-	add_compile_options(-Wno-uninitialized)
-	add_compile_options(-Wno-parentheses)
-	
-    # Clang-only flags
-    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-        # Use libc++ if compiling C++
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20 -stdlib=libc++")
-    endif()
-
-    # GCC-only flags
-    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-        add_compile_options(-Wvolatile)
-        add_compile_options(-fpermissive)
-        add_compile_options(-Wno-attributes)
-        add_compile_options(-Wno-multichar)
-    endif()
-endif()
-
-
-
-if(MSVC)
-    # Supress CRT security warnings
-    add_definitions(/D_CRT_SECURE_NO_WARNINGS)
-    # -fpermissive MSVC equivalent
-    add_compile_options(/permissive-)
-endif()
-
 # Set default C++ standard to C++20
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED true)
@@ -58,6 +26,7 @@ add_subdirectory(VTIL-Architecture)
 add_subdirectory(VTIL-Compiler)
 
 # After all other targets are defined, include the VTIL interface target
+# Use this target in projects that use VTIL: https://github.com/vtil-project/VTIL-Samples
 #
 add_subdirectory(VTIL)
 

--- a/VTIL-Common/CMakeLists.txt
+++ b/VTIL-Common/CMakeLists.txt
@@ -15,3 +15,46 @@ target_include_directories(${PROJECT_NAME} PUBLIC includes)
 
 # Common needs Capstone & Keystone
 target_link_libraries(${PROJECT_NAME} capstone-static keystone)
+
+# Put all VTIL-specific compiler flags here
+# Linking (indirectly) to VTIL-Common will automatically propagate these flags
+# https://www.youtube.com/watch?v=bsXLMQ6WgIk
+
+# https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED YES
+    CXX_EXTENSIONS NO
+)
+
+# For portability on non-MSVC compilers, add some compile options
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+    target_compile_options(${PROJECT_NAME} PUBLIC -Wno-narrowing)
+    target_compile_options(${PROJECT_NAME} PUBLIC -Wno-format-security)
+    target_compile_options(${PROJECT_NAME} PUBLIC -Wno-unused-value)
+    target_compile_options(${PROJECT_NAME} PUBLIC -Wno-uninitialized)
+    target_compile_options(${PROJECT_NAME} PUBLIC -Wno-parentheses)
+    
+    # Clang-only flags
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        # Use libc++ if compiling C++
+        # NOTE: bad practice, technically you should specify this in your CMake invocation
+        target_compile_options(${PROJECT_NAME} PUBLIC -stdlib=libc++)
+        target_link_options(${PROJECT_NAME} PUBLIC -stdlib=libc++)
+    endif()
+
+    # GCC-only flags
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+        target_compile_options(${PROJECT_NAME} PUBLIC -Wvolatile)
+        target_compile_options(${PROJECT_NAME} PUBLIC -fpermissive)
+        target_compile_options(${PROJECT_NAME} PUBLIC -Wno-attributes)
+        target_compile_options(${PROJECT_NAME} PUBLIC -Wno-multichar)
+    endif()
+endif()
+
+if(MSVC)
+    # Supress CRT security warnings
+    target_compile_definitions(${PROJECT_NAME} PUBLIC _CRT_SECURE_NO_WARNINGS)
+    # -fpermissive MSVC equivalent
+    target_compile_options(${PROJECT_NAME} PUBLIC /permissive-)
+endif()


### PR DESCRIPTION
This allows you to delete [this whole duplicated block](https://github.com/vtil-project/VTIL-NativeLifters/blob/f36f0440b0b4b088964333d62bd58573528e235d/CMakeLists.txt#L4) since the target compiler flags are automatically inherited when using `target_link_libraries`

Based on advice from: https://www.youtube.com/watch?v=bsXLMQ6WgIk
