### PR TITLE
More CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,6 @@ option(VTIL_BUILD_TESTS "Build tests" OFF)
 # Append the CMake module search path so we can use our own modules
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
-# Set default C++ standard to C++20
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED true)
-
 # Resolve external dependencies
 # This should automatically pull in Capstone & Keystone as CMake linkable libraries
 include(IncludeDeps)

--- a/VTIL-Architecture/CMakeLists.txt
+++ b/VTIL-Architecture/CMakeLists.txt
@@ -1,40 +1,14 @@
 project(VTIL-Architecture)
 
+file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS *.cpp *.hpp)
+file(GLOB_RECURSE INCLUDES CONFIGURE_DEPENDS includes/*)
+
 add_library(${PROJECT_NAME} STATIC
-    arch/instruction_desc.cpp
-    arch/instruction_desc.hpp
-    arch/instruction_set.hpp
-    arch/operands.hpp
-    arch/register_desc.hpp
-    arch/identifier.hpp
-    misc/debug.hpp
-    routine/basic_block.cpp
-    routine/basic_block.hpp
-    routine/call_convention.hpp
-    routine/instruction.cpp
-    routine/instruction.hpp
-    routine/routine.cpp
-    routine/routine.hpp
-    routine/serialization.cpp
-    routine/serialization.hpp
-    symex/batch_translator.hpp
-    symex/memory.hpp
-    symex/pointer.cpp
-    symex/pointer.hpp
-    symex/translation.cpp
-    symex/translation.hpp
-    symex/variable.cpp
-    symex/variable.hpp
-    trace/cached_tracer.cpp
-    trace/cached_tracer.hpp
-    trace/tracer.cpp
-    trace/tracer.hpp
-    vm/interface.cpp
-    vm/interface.hpp
-    vm/lambda.hpp
-    vm/symbolic.cpp
-    vm/symbolic.hpp
+    ${SOURCES}
+    ${INCLUDES}
 )
+
+source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${SOURCES} ${INCLUDES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC includes)
 target_link_libraries(${PROJECT_NAME} VTIL-Common VTIL-SymEx)

--- a/VTIL-Common/CMakeLists.txt
+++ b/VTIL-Common/CMakeLists.txt
@@ -1,62 +1,14 @@
 project(VTIL-Common)
 
+file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS *.cpp *.hpp)
+file(GLOB_RECURSE INCLUDES CONFIGURE_DEPENDS includes/*)
+
 add_library(${PROJECT_NAME} STATIC
-    arch/amd64/amd64_assembler.cpp
-    arch/amd64/amd64_assembler.hpp
-    arch/amd64/amd64_disassembler.cpp
-    arch/amd64/amd64_disassembler.hpp
-    arch/amd64/amd64_register_details.cpp
-    arch/amd64/amd64_register_details.hpp
-    arch/arm64/arm64_assembler.cpp
-    arch/arm64/arm64_assembler.hpp
-    arch/arm64/arm64_disassembler.cpp
-    arch/arm64/arm64_disassembler.hpp
-    arch/arm64/arm64_register_details.cpp
-    arch/arm64/arm64_register_details.hpp
-    arch/register_mapping.hpp
-    formats/image_descriptor.hpp
-    formats/winpe.cpp
-    formats/winpe.hpp
-    io/asserts.hpp
-    io/formatting.hpp
-    io/logger.cpp
-    io/logger.hpp
-    math/bitwise.hpp
-    math/operable.hpp
-    math/operators.cpp
-    math/operators.hpp
-    query/fixed_iterator.hpp
-    query/query_descriptor.hpp
-    query/range_iterator.hpp
-    query/range_iterator_contract.hpp
-    query/recursive_view.hpp
-    query/view.hpp
-    util/concept.hpp
-    util/conditional_lock.hpp
-    util/constexpr_random.hpp
-    util/copy_on_write.hpp
-    util/critical_section.cpp
-    util/critical_section.hpp
-    util/dynamic_size.hpp
-    util/fnv128.hpp
-    util/fnv64.hpp
-    util/hashable.hpp
-    util/lt_typeid.hpp
-    util/mul128.hpp
-    util/multivariate.hpp
-    util/numeric_iterator.hpp
-    util/optional_reference.hpp
-    util/range.hpp
-    util/reducable.hpp
-    util/reverse_iterator.hpp
-    util/sinkhole.hpp
-    util/stack_container.hpp
-    util/variant.cpp
-    util/variant.hpp
-    util/zip.hpp
-    util/colony.hpp
-    util/object_pool.hpp
+    ${SOURCES}
+    ${INCLUDES}
 )
+
+source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${SOURCES} ${INCLUDES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC includes)
 

--- a/VTIL-Common/CMakeLists.txt
+++ b/VTIL-Common/CMakeLists.txt
@@ -67,12 +67,8 @@ target_link_libraries(${PROJECT_NAME} capstone-static keystone)
 # Linking (indirectly) to VTIL-Common will automatically propagate these flags
 # https://www.youtube.com/watch?v=bsXLMQ6WgIk
 
-# https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/
-set_target_properties(${PROJECT_NAME} PROPERTIES
-    CXX_STANDARD 20
-    CXX_STANDARD_REQUIRED YES
-    CXX_EXTENSIONS NO
-)
+# https://cmake.org/cmake/help/v3.14/manual/cmake-compile-features.7.html#requiring-language-standards
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
 
 # For portability on non-MSVC compilers, add some compile options
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
@@ -100,8 +96,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
 endif()
 
 if(MSVC)
-    # Supress CRT security warnings
-    target_compile_definitions(${PROJECT_NAME} PUBLIC _CRT_SECURE_NO_WARNINGS)
     # -fpermissive MSVC equivalent
     target_compile_options(${PROJECT_NAME} PUBLIC /permissive-)
 endif()

--- a/VTIL-Compiler/CMakeLists.txt
+++ b/VTIL-Compiler/CMakeLists.txt
@@ -1,29 +1,14 @@
 project(VTIL-Compiler)
 
+file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS *.cpp *.hpp)
+file(GLOB_RECURSE INCLUDES CONFIGURE_DEPENDS includes/*)
+
 add_library(${PROJECT_NAME} STATIC
-    common/apply_all.hpp
-    common/auxiliaries.cpp
-    common/auxiliaries.hpp
-    common/interface.hpp
-    optimizer/bblock_extension_pass.cpp
-    optimizer/bblock_extension_pass.hpp
-    optimizer/branch_correction_pass.cpp
-    optimizer/branch_correction_pass.hpp
-    optimizer/dead_code_elimination_pass.cpp
-    optimizer/dead_code_elimination_pass.hpp
-    optimizer/istack_ref_substitution_pass.cpp
-    optimizer/istack_ref_substitution_pass.hpp
-    optimizer/mov_propagation_pass.cpp
-    optimizer/mov_propagation_pass.hpp
-    optimizer/register_renaming_pass.cpp
-    optimizer/register_renaming_pass.hpp
-    optimizer/stack_pinning_pass.cpp
-    optimizer/stack_pinning_pass.hpp
-    optimizer/stack_propagation_pass.cpp
-    optimizer/stack_propagation_pass.hpp
-    optimizer/symbolic_rewrite_pass.cpp
-    optimizer/symbolic_rewrite_pass.hpp
+    ${SOURCES}
+    ${INCLUDES}
 )
+
+source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${SOURCES} ${INCLUDES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC includes)
 target_link_libraries(${PROJECT_NAME} VTIL-Common VTIL-SymEx VTIL-Architecture)

--- a/VTIL-SymEx/CMakeLists.txt
+++ b/VTIL-SymEx/CMakeLists.txt
@@ -1,21 +1,14 @@
 project(VTIL-SymEx)
 
+file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS *.cpp *.hpp)
+file(GLOB_RECURSE INCLUDES CONFIGURE_DEPENDS includes/*)
+
 add_library(${PROJECT_NAME} STATIC
-    directives/directive.cpp
-    directives/directive.hpp
-    directives/fast_matcher.hpp
-    directives/transformer.cpp
-    directives/transformer.hpp
-    expressions/expression.cpp
-    expressions/expression.hpp
-    expressions/unique_identifier.cpp
-    expressions/unique_identifier.hpp
-    simplifier/boolean_directives.cpp
-    simplifier/boolean_directives.hpp
-    simplifier/directives.hpp
-    simplifier/simplifier.cpp
-    simplifier/simplifier.hpp
+    ${SOURCES}
+    ${INCLUDES}
 )
+
+source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${SOURCES} ${INCLUDES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC includes)
 target_link_libraries(${PROJECT_NAME} VTIL-Common)

--- a/VTIL-Tests/CMakeLists.txt
+++ b/VTIL-Tests/CMakeLists.txt
@@ -1,9 +1,9 @@
 project(VTIL-Tests)
 
+file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS *.cpp *.hpp *.h)
+
 add_executable(${PROJECT_NAME}
-    doctest.h
-    dummy.cpp
-    main.cpp
+	${SOURCES}
 )
 
 target_link_libraries(${PROJECT_NAME} VTIL)


### PR DESCRIPTION
- C++20 is now a requirement in the target instead of manually `set`. This allows projects using VTIL to not have to also manually set C++20
- `GLOB_RECURSE` is used to automatically populate the source files. Since CMake 3.17 this can be done safely with `CONFIGURE_DEPENDS` (https://stackoverflow.com/a/32412044/1806760)
- Filters are properly done when generating a Visual Studio project (using `source_group(TREE ...)`):
   ![image](https://user-images.githubusercontent.com/2458265/86474751-cb549d00-bd43-11ea-91f8-d1d7e78230dc.png)
