### PR TITLE
Fix pe_image::get_section preserving null padding

### DIFF
--- a/VTIL-Common/formats/winpe.cpp
+++ b/VTIL-Common/formats/winpe.cpp
@@ -552,7 +552,7 @@ namespace vtil
 		//
 		auto scn_header = nt_headers->get_section( index );
 		return {
-			.name = { scn_header->name, scn_header->name + ( scn_header->name[ LEN_SECTION_NAME - 1 ] ? strlen( scn_header->name ) : LEN_SECTION_NAME ) },
+			.name = { scn_header->name, scn_header->name + ( scn_header->name[ LEN_SECTION_NAME - 1 ] ? LEN_SECTION_NAME : strlen( scn_header->name ) ) },
 			.valid = true,
 			.read = ( bool ) scn_header->characteristics.mem_read,
 			.write = ( bool ) scn_header->characteristics.mem_write,


### PR DESCRIPTION
Cases in the conditional were switched, now when there is null termination ( `scn_header->name[ LEN_SECTION_NAME - 1 ] == false`) `strlen` is used to trim the nulls, otherwise return all 8 characters (`LEN_SECTION_NAME`).