### PR TITLE
Add VTIL install target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.14.5)
 project(VTIL)
 
 option(VTIL_BUILD_TESTS "Build tests" OFF)
+option(VTIL_INSTALL "Generate install target" ON)
 
 # Append the CMake module search path so we can use our own modules
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)

--- a/VTIL-Architecture/CMakeLists.txt
+++ b/VTIL-Architecture/CMakeLists.txt
@@ -12,3 +12,8 @@ source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${SOURCES} ${INCLUDES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC includes)
 target_link_libraries(${PROJECT_NAME} VTIL-Common VTIL-SymEx)
+
+if(VTIL_INSTALL)
+    install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+    install(DIRECTORY includes/ DESTINATION include FILES_MATCHING PATTERN "*")
+endif()

--- a/VTIL-Architecture/CMakeLists.txt
+++ b/VTIL-Architecture/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(VTIL-Architecture)
+project(VTIL-Architecture VERSION 0.1.0)
 
 file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS *.cpp *.hpp)
 file(GLOB_RECURSE INCLUDES CONFIGURE_DEPENDS includes/*)
@@ -13,7 +13,10 @@ source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${SOURCES} ${INCLUDES})
 target_include_directories(${PROJECT_NAME} PUBLIC includes)
 target_link_libraries(${PROJECT_NAME} VTIL-Common VTIL-SymEx)
 
+configure_file(VTIL-Architecture.pc.in ${CMAKE_BINARY_DIR}/VTIL-Architecture.pc @ONLY)
+
 if(VTIL_INSTALL)
     install(TARGETS ${PROJECT_NAME} DESTINATION lib)
     install(DIRECTORY includes/ DESTINATION include FILES_MATCHING PATTERN "*")
+    install(FILES ${CMAKE_BINARY_DIR}/VTIL-Architecture.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/VTIL-Architecture/VTIL-Architecture.pc.in
+++ b/VTIL-Architecture/VTIL-Architecture.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: VTIL-Architecture
+Description: VTIL architecture libraries
+Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
+URL: https://vtil.org
+archive=${libdir}/libVTIL-Architecture.a
+Requires: VTIL-Common VTIL-SymEx
+Libs: -L${libdir} -lVTIL-Architecture
+Cflags: -I${includedir}

--- a/VTIL-Common/CMakeLists.txt
+++ b/VTIL-Common/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(VTIL-Common)
+project(VTIL-Common VERSION 0.1.0)
 
 file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS *.cpp *.hpp)
 file(GLOB_RECURSE INCLUDES CONFIGURE_DEPENDS includes/*)
@@ -53,7 +53,10 @@ endif()
 find_package(Threads REQUIRED)
 target_link_libraries(${PROJECT_NAME} PUBLIC ${CMAKE_THREAD_LIBS_INIT})
 
+configure_file(VTIL-Common.pc.in ${CMAKE_BINARY_DIR}/VTIL-Common.pc @ONLY)
+
 if(VTIL_INSTALL)
     install(TARGETS ${PROJECT_NAME} DESTINATION lib)
     install(DIRECTORY includes/ DESTINATION include FILES_MATCHING PATTERN "*")
+    install(FILES ${CMAKE_BINARY_DIR}/VTIL-Common.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/VTIL-Common/CMakeLists.txt
+++ b/VTIL-Common/CMakeLists.txt
@@ -52,3 +52,8 @@ endif()
 # Include Threads
 find_package(Threads REQUIRED)
 target_link_libraries(${PROJECT_NAME} PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+
+if(VTIL_INSTALL)
+    install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+    install(DIRECTORY includes/ DESTINATION include FILES_MATCHING PATTERN "*")
+endif()

--- a/VTIL-Common/VTIL-Common.pc.in
+++ b/VTIL-Common/VTIL-Common.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: VTIL-Common
+Description: VTIL common libraries
+Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
+URL: https://vtil.org
+archive=${libdir}/libVTIL-Common.a
+Libs: -L${libdir} -lVTIL-Common
+Cflags: -I${includedir}

--- a/VTIL-Compiler/CMakeLists.txt
+++ b/VTIL-Compiler/CMakeLists.txt
@@ -12,3 +12,8 @@ source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${SOURCES} ${INCLUDES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC includes)
 target_link_libraries(${PROJECT_NAME} VTIL-Common VTIL-SymEx VTIL-Architecture)
+
+if(VTIL_INSTALL)
+    install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+    install(DIRECTORY includes/ DESTINATION include FILES_MATCHING PATTERN "*")
+endif()

--- a/VTIL-Compiler/CMakeLists.txt
+++ b/VTIL-Compiler/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(VTIL-Compiler)
+project(VTIL-Compiler VERSION 0.1.0)
 
 file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS *.cpp *.hpp)
 file(GLOB_RECURSE INCLUDES CONFIGURE_DEPENDS includes/*)
@@ -13,7 +13,10 @@ source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${SOURCES} ${INCLUDES})
 target_include_directories(${PROJECT_NAME} PUBLIC includes)
 target_link_libraries(${PROJECT_NAME} VTIL-Common VTIL-SymEx VTIL-Architecture)
 
+configure_file(VTIL-Compiler.pc.in ${CMAKE_BINARY_DIR}/VTIL-Compiler.pc @ONLY)
+
 if(VTIL_INSTALL)
     install(TARGETS ${PROJECT_NAME} DESTINATION lib)
     install(DIRECTORY includes/ DESTINATION include FILES_MATCHING PATTERN "*")
+    install(FILES ${CMAKE_BINARY_DIR}/VTIL-Compiler.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/VTIL-Compiler/VTIL-Compiler.pc.in
+++ b/VTIL-Compiler/VTIL-Compiler.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: VTIL-Compiler
+Description: VTIL compiler libraries
+Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
+URL: https://vtil.org
+archive=${libdir}/libVTIL-Compiler.a
+Requires: VTIL-Common VTIL-SymEx VTIL-Architecture
+Libs: -L${libdir} -lVTIL-Compiler
+Cflags: -I${includedir}

--- a/VTIL-SymEx/CMakeLists.txt
+++ b/VTIL-SymEx/CMakeLists.txt
@@ -17,3 +17,8 @@ if(MSVC)
     # /bigobj for reasons
     target_compile_options(${PROJECT_NAME} PRIVATE /bigobj)
 endif()
+
+if(VTIL_INSTALL)
+    install(TARGETS ${PROJECT_NAME} DESTINATION lib)
+    install(DIRECTORY includes/ DESTINATION include FILES_MATCHING PATTERN "*")
+endif()

--- a/VTIL-SymEx/CMakeLists.txt
+++ b/VTIL-SymEx/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(VTIL-SymEx)
+project(VTIL-SymEx VERSION 0.1.0)
 
 file(GLOB_RECURSE SOURCES CONFIGURE_DEPENDS *.cpp *.hpp)
 file(GLOB_RECURSE INCLUDES CONFIGURE_DEPENDS includes/*)
@@ -18,7 +18,10 @@ if(MSVC)
     target_compile_options(${PROJECT_NAME} PRIVATE /bigobj)
 endif()
 
+configure_file(VTIL-SymEx.pc.in ${CMAKE_BINARY_DIR}/VTIL-SymEx.pc @ONLY)
+
 if(VTIL_INSTALL)
     install(TARGETS ${PROJECT_NAME} DESTINATION lib)
     install(DIRECTORY includes/ DESTINATION include FILES_MATCHING PATTERN "*")
+    install(FILES ${CMAKE_BINARY_DIR}/VTIL-SymEx.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/VTIL-SymEx/VTIL-SymEx.pc.in
+++ b/VTIL-SymEx/VTIL-SymEx.pc.in
@@ -1,0 +1,13 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: VTIL-SymEx
+Description: VTIL symbolic execution libraries
+Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
+URL: https://vtil.org
+archive=${libdir}/libVTIL-SymEx.a
+Requires: VTIL-Common
+Libs: -L${libdir} -lVTIL-SymEx
+Cflags: -I${includedir}

--- a/VTIL/CMakeLists.txt
+++ b/VTIL/CMakeLists.txt
@@ -10,4 +10,8 @@ target_include_directories(${PROJECT_NAME} INTERFACE includes)
 
 # Mark all other VTIL targets as a dependency of VTIL
 #
-target_link_libraries(${PROJECT_NAME} INTERFACE VTIL-Architecture VTIL-SymEx VTIL-Common VTIL-Compiler) 
+target_link_libraries(${PROJECT_NAME} INTERFACE VTIL-Architecture VTIL-SymEx VTIL-Common VTIL-Compiler)
+
+if(VTIL_INSTALL)
+    install(DIRECTORY includes/ DESTINATION include FILES_MATCHING PATTERN "*")
+endif()

--- a/VTIL/CMakeLists.txt
+++ b/VTIL/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(VTIL)
+project(VTIL VERSION 0.1.0)
 
 # This builds no sources -- it simply aliases a collection of all other targets created by VTIL
 #
@@ -12,6 +12,9 @@ target_include_directories(${PROJECT_NAME} INTERFACE includes)
 #
 target_link_libraries(${PROJECT_NAME} INTERFACE VTIL-Architecture VTIL-SymEx VTIL-Common VTIL-Compiler)
 
+configure_file(VTIL.pc.in ${CMAKE_BINARY_DIR}/VTIL.pc @ONLY)
+
 if(VTIL_INSTALL)
     install(DIRECTORY includes/ DESTINATION include FILES_MATCHING PATTERN "*")
+    install(FILES ${CMAKE_BINARY_DIR}/VTIL.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif()

--- a/VTIL/VTIL.pc.in
+++ b/VTIL/VTIL.pc.in
@@ -1,0 +1,12 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: VTIL
+Description: VTIL libraries
+Version: @PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@
+URL: https://vtil.org
+Requires: VTIL-Common VTIL-Architecture VTIL-SymEx VTIL-Compiler
+Libs: -L${libdir}
+Cflags: -I${includedir}

--- a/cmake/IncludeDeps.cmake
+++ b/cmake/IncludeDeps.cmake
@@ -22,12 +22,14 @@ set(CAPSTONE_BUILD_TESTS OFF CACHE BOOL "")
 set(CAPSTONE_BUILD_CSTOOL OFF CACHE BOOL "")
 set(CAPSTONE_BUILD_STATIC_RUNTIME OFF CACHE BOOL "")
 set(CAPSTONE_BUILD_SHARED OFF CACHE BOOL "")
+set(CAPSTONE_INSTALL OFF CACHE BOOL "")
 set(KEYSTONE_BUILD_STATIC_RUNTIME OFF CACHE BOOL "")
+set(KEYSTONE_INSTALL OFF CACHE BOOL "")
 set(BUILD_LIBS_ONLY ON CACHE BOOL "")
 
 # Actually fetch dependencies
-FetchDep(Capstone "https://github.com/aquynh/capstone.git")
-FetchDep(Keystone "https://github.com/mrexodia/keystone.git")
+FetchDep(Capstone "https://github.com/vtil-project/capstone.git")
+FetchDep(Keystone "https://github.com/vtil-project/keystone.git")
 
 # These CMake projects erroneously do not specify INTERFACE include directory, so
 # we need to add it ourselves.


### PR DESCRIPTION
- Prevent capstone and keystone from being passed for `make install`
- Add pkg-config for VTIL
- `make install` target for VTIL