### PR TITLE
Fix failed validation for wrong bit_count()

### DIFF
--- a/VTIL-Architecture/routine/instruction.cpp
+++ b/VTIL-Architecture/routine/instruction.cpp
@@ -72,7 +72,7 @@ namespace vtil
 		//
 		for ( auto& list : { base->branch_operands_rip, base->branch_operands_vip } )
 			for ( int idx : list )
-				cvalidate( operands[ idx ].bit_count() == 64 );
+				cvalidate( operands[ idx ].bit_count() == 64 || operands[ idx ].is_immediate() );
 		return true;
 	}
 


### PR DESCRIPTION
For some rare targets, this assertion fails:

```cpp
cvalidate( operands[ idx ].bit_count() == 64 );
```

Can mentioned it should likely be fine if the operand is immediate, so adding this to the equation solved the problem.