### PR TITLE
Fix build in clang 11.1.0 by adding #include

### DIFF
--- a/VTIL-Common/io/strong_formatting.hpp
+++ b/VTIL-Common/io/strong_formatting.hpp
@@ -27,6 +27,7 @@
 //
 #pragma once
 #include "formatting.hpp"
+#include <cmath>
 
 // Trivial types with useful explict formatting wrappers.
 //
@@ -110,7 +111,7 @@ namespace vtil::format
 			//
 			for ( auto [abbrv, i] : backwards( zip( unit_abbrv, iindices ) ) )
 			{
-				double limit = pow( 1024.0, i );
+				double limit = std::pow( 1024.0, i );
 
 				// If value is larger than the unit given or if we're at the last unit:
 				//


### PR DESCRIPTION
```
[ 83%] Building CXX object VTIL-Common/CMakeFiles/VTIL-Common.dir/arch/amd64/amd64_disassembler.cpp.o
In file included from VTIL-Core/VTIL-Common/arch/amd64/amd64_disassembler.cpp:39:
In file included from VTIL-Core/VTIL-Common/arch/amd64/amd64_disassembler.hpp:47:
In file included from VTIL-Core/VTIL-Common/arch/amd64/../../io/formatting.hpp:44:
VTIL-Core/VTIL-Common/arch/amd64/../../io/strong_formatting.hpp:113:20: error: use of undeclared identifier 'pow'
                                double limit = pow( 1024.0, i );
                                               ^
```