### PR TITLE
fix register corrupt

### DIFF
--- a/VTIL-Compiler/optimizer/fast_propagation_pass.cpp
+++ b/VTIL-Compiler/optimizer/fast_propagation_pass.cpp
@@ -366,6 +366,8 @@ namespace vtil::optimizer
 								blk->insert( prev_it, { &ins::bshl, { { tmp }, { store_offset * 8, 64 } } } );
 							blk->insert( prev_it, { &ins::band, { { tmp }, { store_mask, 64 } } } );
 							blk->insert( prev_it, { &ins::bor, { { final_tmp }, { tmp } } } );
+
+							first = false;
 						}
 					}
 


### PR DESCRIPTION
I had to change this in order to get fully accurate optimization of VMP 3.x entry point.