### PR TITLE
Added new "thunk" removal pass (Single jump bblock)

### DIFF
--- a/VTIL-Architecture/symex/variable.cpp
+++ b/VTIL-Architecture/symex/variable.cpp
@@ -396,7 +396,10 @@ namespace vtil::symbolic
 						access_details details;
 						fill_displacement( &details, mem.base, pointer{ std::move( limit ) }, tracer, xblock );
 						if ( !details.is_unknown() && ( details.bit_offset + var.bit_count() ) <= 0 )
+						{
 							result += { .bit_offset = 0, .bit_count = var.bit_count(), .read = false, .write = true };
+							return result;
+						}
 					}
 				}
 

--- a/VTIL-Compiler/common/apply_all.hpp
+++ b/VTIL-Compiler/common/apply_all.hpp
@@ -95,6 +95,11 @@ namespace vtil::optimizer
 		collective_propagation_pass,
 		//fast_dead_code_elimination_pass,
 		exhaust_pass<
+			branch_correction_pass,
+			bblock_extension_pass,
+			bblock_thunk_removal_pass
+		>,
+		exhaust_pass<
 			conditional_pass<
 				symbolic_rewrite_pass<false>,
 				exhaust_pass<
@@ -104,8 +109,7 @@ namespace vtil::optimizer
 				>
 			>
 		>,
-		stack_pinning_pass,
-		bblock_thunk_removal_pass
+		stack_pinning_pass
 	>;
 
 	// Local optimization pass.

--- a/VTIL-Compiler/common/apply_all.hpp
+++ b/VTIL-Compiler/common/apply_all.hpp
@@ -30,6 +30,7 @@
 #include "../optimizer/stack_pinning_pass.hpp"
 #include "../optimizer/istack_ref_substitution_pass.hpp"
 #include "../optimizer/bblock_extension_pass.hpp"
+#include "../optimizer/bblock_thunk_removal_pass.hpp"
 #include "../optimizer/stack_propagation_pass.hpp"
 #include "../optimizer/dead_code_elimination_pass.hpp"
 #include "../optimizer/fast_dead_code_elimination_pass.hpp"
@@ -103,7 +104,8 @@ namespace vtil::optimizer
 				>
 			>
 		>,
-		stack_pinning_pass
+		stack_pinning_pass,
+		bblock_thunk_removal_pass
 	>;
 
 	// Local optimization pass.

--- a/VTIL-Compiler/common/auxiliaries.cpp
+++ b/VTIL-Compiler/common/auxiliaries.cpp
@@ -137,8 +137,7 @@ namespace vtil::optimizer::aux
 						symbolic::expression exp =
 							local_var.mem().decay()
 							- local_var.at.block->sp_offset
-							//+ rel_ptr( symbolic::variable{ it.block->begin(), REG_SP } )
-							+ symbolic::variable{ it.block->begin(), REG_SP }.to_expression()
+							+ rel_ptr( symbolic::variable{ it.block->begin(), REG_SP } )							
 							- symbolic::variable{ local_var.at.block->begin(), REG_SP }.to_expression();
 						local_var = symbolic::variable{ it.block->begin(), { symbolic::pointer{ exp }, local_var.mem().bit_count } };
 					}

--- a/VTIL-Compiler/common/auxiliaries.cpp
+++ b/VTIL-Compiler/common/auxiliaries.cpp
@@ -137,7 +137,8 @@ namespace vtil::optimizer::aux
 						symbolic::expression exp =
 							local_var.mem().decay()
 							- local_var.at.block->sp_offset
-							+ rel_ptr( symbolic::variable{ it.block->begin(), REG_SP } )
+							//+ rel_ptr( symbolic::variable{ it.block->begin(), REG_SP } )
+							+ symbolic::variable{ it.block->begin(), REG_SP }.to_expression()
 							- symbolic::variable{ local_var.at.block->begin(), REG_SP }.to_expression();
 						local_var = symbolic::variable{ it.block->begin(), { symbolic::pointer{ exp }, local_var.mem().bit_count } };
 					}

--- a/VTIL-Compiler/optimizer/bblock_thunk_removal_pass.cpp
+++ b/VTIL-Compiler/optimizer/bblock_thunk_removal_pass.cpp
@@ -58,6 +58,11 @@ namespace vtil::optimizer
 		{
 			fassert(blk->front() == blk->back());
 
+			// This should never happen in real world cases. We check for "jmp only", which implies zero changes to the stack
+			// This might happen if you write a test case, but shouldn't be possible otherwise
+			//
+			fassert(blk->sp_offset == 0);
+
 			basic_block* next = blk->next[0];
 			basic_block* prev = blk->prev[0];				
 

--- a/VTIL-Compiler/optimizer/bblock_thunk_removal_pass.cpp
+++ b/VTIL-Compiler/optimizer/bblock_thunk_removal_pass.cpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 Can Boluk and contributors of the VTIL Project   
+// All rights reserved.   
+//    
+// Redistribution and use in source and binary forms, with or without   
+// modification, are permitted provided that the following conditions are met: 
+//    
+// 1. Redistributions of source code must retain the above copyright notice,   
+//    this list of conditions and the following disclaimer.   
+// 2. Redistributions in binary form must reproduce the above copyright   
+//    notice, this list of conditions and the following disclaimer in the   
+//    documentation and/or other materials provided with the distribution.   
+// 3. Neither the name of VTIL Project nor the names of its contributors
+//    may be used to endorse or promote products derived from this software 
+//    without specific prior written permission.   
+//    
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE   
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE  
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE   
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR   
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF   
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN   
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)   
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE  
+// POSSIBILITY OF SUCH DAMAGE.        
+//
+#include "bblock_thunk_removal_pass.hpp"
+
+namespace vtil::optimizer
+{
+	// Implement the pass.
+	//
+	size_t bblock_thunk_removal_pass::pass(basic_block* blk, bool xblock)
+	{
+		fassert( xblock );		
+
+		// Skip if already visited.
+		//
+		if ( !visited.emplace( blk ).second )
+			return 0;
+
+		size_t counter = 0;		
+
+		// Check if the only instruction is a jump imm to the next basic block
+		// Also make sure that the block is only referenced by one previous block
+		//
+		if (blk->size() == 1 &&			//only one instruction
+			blk->next.size() == 1 &&	//only accessed from one path
+			blk->prev.size() == 1 &&	//only jumping to one destination				
+			blk->back().base->is_branching_virt())
+		{
+			fassert(blk->front() == blk->back());
+
+			basic_block* next = blk->next[0];
+			basic_block* prev = blk->prev[0];				
+
+			// Remove the block from the next hierarchy
+			//
+			for (size_t i = 0; i < prev->next.size(); i++)
+			{
+				if (prev->next[i]->entry_vip == blk->entry_vip)
+					prev->next[i] = next;
+			}
+
+			// Remove the block from the prev hierarchy
+			//
+			for (size_t i = 0; i < next->prev.size(); i++)
+			{
+				if (next->prev[i]->entry_vip == blk->entry_vip)
+					next->prev[i] = prev;
+			}
+			
+			fassert(prev->back().base->branch_operands_vip.size() != 0);
+
+			for (size_t i = 0; i < prev->back().operands.size(); i++)
+			{
+				if (!prev->back().operands[i].is_immediate())
+					continue;
+
+				auto& ins = make_mutable(prev->back());						
+				if (ins.operands[i].imm().ival == blk->entry_vip)
+				{
+					ins.operands[i].imm().ival = next->entry_vip;
+				}	
+			}					
+			
+			obsolete_blocks.emplace(blk);
+			counter++;
+		}
+
+		// Recurse into destinations:
+		//
+		for ( auto* dst : blk->next )
+			counter += pass( dst, true );
+
+		// Remove queued obsolete blocks
+		// We can only do that after completing every recusive path
+		//
+		if (visited.size() == blk->owner->num_blocks())
+		{
+			for (auto it : obsolete_blocks)
+				blk->owner->delete_block(const_cast<vtil::basic_block*>(it));
+		}
+
+		return counter;
+	}
+	size_t bblock_thunk_removal_pass::xpass(routine* rtn)
+	{
+		// Invoke recursive optimizer starting from entry point.
+		//
+		visited.reserve( rtn->num_blocks() );
+		return pass( rtn->entry_point, true );
+	}
+};

--- a/VTIL-Compiler/optimizer/bblock_thunk_removal_pass.hpp
+++ b/VTIL-Compiler/optimizer/bblock_thunk_removal_pass.hpp
@@ -40,6 +40,7 @@ namespace vtil::optimizer
 		//
 		path_set visited;
 		path_set obsolete_blocks;
+		basic_block* first_block;
 
 		size_t pass( basic_block* blk, bool xblock = false ) override;
 		size_t xpass( routine* rtn ) override;

--- a/VTIL-Compiler/optimizer/bblock_thunk_removal_pass.hpp
+++ b/VTIL-Compiler/optimizer/bblock_thunk_removal_pass.hpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 Can Boluk and contributors of the VTIL Project   
+// All rights reserved.   
+//    
+// Redistribution and use in source and binary forms, with or without   
+// modification, are permitted provided that the following conditions are met: 
+//    
+// 1. Redistributions of source code must retain the above copyright notice,   
+//    this list of conditions and the following disclaimer.   
+// 2. Redistributions in binary form must reproduce the above copyright   
+//    notice, this list of conditions and the following disclaimer in the   
+//    documentation and/or other materials provided with the distribution.   
+// 3. Neither the name of VTIL Project nor the names of its contributors
+//    may be used to endorse or promote products derived from this software 
+//    without specific prior written permission.   
+//    
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE   
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE  
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE   
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR   
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF   
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS   
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN   
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)   
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE  
+// POSSIBILITY OF SUCH DAMAGE.        
+//
+#pragma once
+#include <vtil/arch>
+#include <set>
+#include "../common/interface.hpp"
+
+namespace vtil::optimizer
+{
+	// Attempts to detect and remove basic blocks with a single branch instruction (e.g jmp 0xnextblockaddr blocks).
+	//
+	struct bblock_thunk_removal_pass : pass_interface<execution_order::custom>
+	{
+		// List of blocks we have already visited, refreshed per xpass call.
+		//
+		path_set visited;
+		path_set obsolete_blocks;
+
+		size_t pass( basic_block* blk, bool xblock = false ) override;
+		size_t xpass( routine* rtn ) override;
+	};
+};

--- a/VTIL-Tests/dummy.cpp
+++ b/VTIL-Tests/dummy.cpp
@@ -130,7 +130,6 @@ DOCTEST_TEST_CASE("Optimization stack_pinning_pass")
 
 }
 
-
 DOCTEST_TEST_CASE("Optimization istack_ref_substitution_pass")
 {
     vtil::logger::log("\n\n>> %s \n", __FUNCTION__);
@@ -164,7 +163,6 @@ DOCTEST_TEST_CASE("Optimization istack_ref_substitution_pass")
 
 }
 
-
 DOCTEST_TEST_CASE("Optimization stack_propagation_pass")
 {
     vtil::logger::log("\n\n>> %s \n", __FUNCTION__);
@@ -196,7 +194,6 @@ DOCTEST_TEST_CASE("Optimization stack_propagation_pass")
     CHECK(ins.operands[1].imm().ival == 0x1234);
 }
 
-
 DOCTEST_TEST_CASE("Optimization dead_code_elimination_pass")
 {
     vtil::logger::log("\n\n>> %s \n", __FUNCTION__);
@@ -219,7 +216,6 @@ DOCTEST_TEST_CASE("Optimization dead_code_elimination_pass")
 
     CHECK(block->size() == 2);
 }
-
 
 DOCTEST_TEST_CASE("Optimization mov_propagation_pass")
 {
@@ -252,7 +248,6 @@ DOCTEST_TEST_CASE("Optimization mov_propagation_pass")
     CHECK(ins.operands[0].reg().local_id == registers::bx);
     CHECK(ins.operands[1].imm().ival == 0x1);
 }
-
 
 DOCTEST_TEST_CASE("Optimization register_renaming_pass")
 {
@@ -289,7 +284,6 @@ DOCTEST_TEST_CASE("Optimization register_renaming_pass")
     CHECK(ins.operands[0].reg().local_id == registers::bx);
     CHECK(ins.operands[1].imm().ival == 0x1);
 }
-
 
 DOCTEST_TEST_CASE("Optimization symbolic_rewrite_pass<true>")
 {
@@ -341,7 +335,6 @@ DOCTEST_TEST_CASE("Optimization symbolic_rewrite_pass<true>")
     CHECK(ins.operands[0].reg().to_string() == "$sp");
     CHECK(ins.operands[2].imm().ival == 0x1);
 }
-
 
 DOCTEST_TEST_CASE("Optimization dead_code_elimination_pass")
 {
@@ -469,11 +462,9 @@ DOCTEST_TEST_CASE("Optimization dead_code_elimination_pass")
         // Cant optimize the block1 (strq) because we use it in block3
         CHECK( block1->size() == 4 );
     }
-
-
 }
 
-DOCTEST_TEST_CASE("Simplification")
+DOCTEST_TEST_CASE("Optimization Simplification")
 {
     vtil::logger::log("\n\n>> %s \n", __FUNCTION__);
     auto block = vtil::basic_block::begin(0x1337);
@@ -557,76 +548,125 @@ DOCTEST_TEST_CASE("Optimization bblock_thunk_removal_pass")
 {
 	vtil::logger::log("\n\n>> %s \n", __FUNCTION__);
 
-	auto block1 = vtil::basic_block::begin((uintptr_t)0x1000);
-	auto rtn = block1->owner;
-	{
-		// 0x1000: js eflags@11:1 0x2000, 0x3000
-		block1->js(vtil::REG_FLAGS.select(1, 11), (uintptr_t)0x2000, (uintptr_t)0x3000);
+	//Check reduction
+	{	
+		auto block1 = vtil::basic_block::begin((uintptr_t)0x1000);
+		auto rtn = block1->owner;
+		{
+			// 0x1000: js eflags@11:1 0x2000, 0x3000
+			block1->js(vtil::REG_FLAGS.select(1, 11), (uintptr_t)0x2000, (uintptr_t)0x3000);
+		}
+		auto block2 = block1->fork((uintptr_t)0x2000);
+		{
+			// 0x2000: jmp 0x4000
+			block2->jmp((uintptr_t)0x4000);
+			block2->fork((uintptr_t)0x4000);
+		}
+		auto block3 = block1->fork((uintptr_t)0x3000);
+		{
+			// 0x3000: jmp 0x4000
+			block3->jmp((uintptr_t)0x4000);
+			block3->fork((uintptr_t)0x4000);
+		}
+		auto block4 = rtn->get_block((uintptr_t)0x4000);
+		{
+			// 0x4000: jmp 0x5000
+			block4->jmp((uintptr_t)0x5000);
+			block4->fork((uintptr_t)0x5000);
+		}
+		auto block5 = rtn->get_block((uintptr_t)0x5000);
+		{
+			// 0x5000: vexit 0
+			block5->vexit((uintptr_t)0);
+		}
+		vtil::logger::log("Before:\n");
+		vtil::debug::dump(rtn);
+
+		vtil::optimizer::apply_all(rtn);
+		vtil::logger::log("After:\n");
+		vtil::debug::dump(rtn);	
+
+		//block1 is now vexit
+		auto ins = (*block1)[0];
+		CHECK(ins.base == &vtil::ins::vexit);
+		CHECK(ins.operands.size() == 1);
 	}
-	auto block2 = block1->fork((uintptr_t)0x2000);
+
+	//Check tracer validity
 	{
-		// 0x2000: jmp 0x4000
-		block2->jmp((uintptr_t)0x4000);
-		block2->fork((uintptr_t)0x4000);
+		auto block1 = vtil::basic_block::begin(0x1000);
+		{			
+			block1->push((uintptr_t)0x12345678);			
+			block1->js(registers::cx, 0x2000ull, 0x3000ull);
+		}		
+		auto block2 = block1->fork(0x2000ull);
+		{			
+			block2->jmp(0x4000ull);
+			block2->fork(0x4000ull);
+		}
+		auto block3 = block1->fork(0x3000ull);
+		{			
+			block3->jmp(0x4000ull);
+			block3->fork(0x4000ull);
+		}
+		auto block4 = block1->owner->get_block(0x4000ull);
+		{			
+			block4->pop(registers::ax);
+			block4->vexit(0ull);
+		}
+
+		vtil::logger::log("Before:\n");
+		vtil::debug::dump(block1->owner);
+
+		//Check tracer result before running passes
+		vtil::tracer tracer;
+		auto exp1 = tracer.rtrace_p({ std::prev(block4->end()), vtil::register_desc(registers::ax) });
+		
+		vtil::optimizer::apply_all(block1->owner);
+		vtil::logger::log("After:\n");
+		vtil::debug::dump(block1->owner);	
+
+		//Check tracer result before running passes
+		vtil::tracer tracer2;
+		auto exp2 = tracer2.rtrace_p({ std::prev(block1->end()), vtil::register_desc(registers::ax) });			
+		
+		CHECK(exp1.get()->equals(*exp2.get()));
 	}
-	auto block3 = block1->fork((uintptr_t)0x3000);
+}
+
+DOCTEST_TEST_CASE("Optimization branch_correction_pass")
+{
+	vtil::logger::log("\n\n>> %s \n", __FUNCTION__);
+
+	auto block1 = vtil::basic_block::begin(0x1337);
+
+	vtil::register_desc reg_flags(vtil::register_physical | vtil::register_flags, 0, vtil::arch::bit_count, 0);
+	vtil::register_desc reg_ecx(vtil::register_physical, registers::cx, vtil::arch::bit_count, 0);
+
 	{
-		// 0x3000: jmp 0x4000
-		block3->jmp((uintptr_t)0x4000);
-		block3->fork((uintptr_t)0x4000);
+		block1->mov(reg_flags.select(1, 0), 0x0);
+		block1->js(reg_flags.select(1, 0), (uintptr_t)0x2000, (uintptr_t)0x3000);
 	}
-	auto block4 = rtn->get_block((uintptr_t)0x4000);
-	{
-		// 0x4000: jmp 0x5000
-		block4->jmp((uintptr_t)0x5000);
-		block4->fork((uintptr_t)0x5000);
+
+	auto block2 = block1->fork(0x2000);
+	{		
+		block2->push(reg_flags); //dummy pin
+		block2->vexit(0ull);	 // marks the end
 	}
-	auto block5 = rtn->get_block((uintptr_t)0x5000);
-	{
-		// 0x5000: vexit 0
-		block5->vexit((uintptr_t)0);
+
+	auto block3 = block1->fork(0x3000);
+	{		
+		block3->push(reg_flags); //dummy pin
+		block3->vexit(0ull);	 // marks the end
 	}
-	vtil::logger::log("Before:\n");
-	vtil::debug::dump(rtn);
 
-	vtil::optimizer::bblock_thunk_removal_pass{}(rtn);
-	vtil::logger::log("After:\n");
-	vtil::debug::dump(rtn);
+	vtil::logger::log(":: Before:\n");
+	vtil::debug::dump(block1->owner);
 
-	//block1 now points to block4
-	auto ins = (*block1)[0];
-	CHECK(ins.base == &vtil::ins::jmp);
-	CHECK(ins.operands.size() == 1);
-	CHECK(ins.operands[0].is_immediate());
-	CHECK(ins.operands[0].imm().ival == block4->entry_vip);
+	vtil::optimizer::apply_all(block1->owner);
 
-	//block4 still points to block5
-	ins = (*block4)[0];
-	CHECK(ins.base == &vtil::ins::jmp);
-	CHECK(ins.operands.size() == 1);
-	CHECK(ins.operands[0].is_immediate());
-	CHECK(ins.operands[0].imm().ival == block5->entry_vip);
-
-	//block5 is still vexit
-	ins = (*block5)[0];
-	CHECK(ins.base == &vtil::ins::vexit);
-	CHECK(block5->size() == 1);
-
-	// Simulate another pass
-	//
-	vtil::optimizer::bblock_thunk_removal_pass{}(rtn);
-	vtil::logger::log("After secondary:\n");
-	vtil::debug::dump(rtn);
-
-	//block1 now points to block5
-	ins = (*block1)[0];
-	CHECK(ins.base == &vtil::ins::jmp);
-	CHECK(ins.operands.size() == 1);
-	CHECK(ins.operands[0].is_immediate());
-	CHECK(ins.operands[0].imm().ival == block5->entry_vip);
-
-	//block5 is still vexit
-	ins = (*block5)[0];
-	CHECK(ins.base == &vtil::ins::vexit);
-	CHECK(block5->size() == 1);
+	vtil::logger::log(":: After:\n");
+	vtil::debug::dump(block1->owner);	
+		
+	CHECK(block1->size() == 3);
 }

--- a/VTIL-Tests/dummy.cpp
+++ b/VTIL-Tests/dummy.cpp
@@ -594,6 +594,8 @@ DOCTEST_TEST_CASE("Optimization bblock_thunk_removal_pass")
 
 	//Check tracer validity
 	{
+		vtil::register_desc reg_ax(vtil::register_physical, registers::ax, vtil::arch::bit_count, 0);
+
 		auto block1 = vtil::basic_block::begin(0x1000);
 		{			
 			block1->push((uintptr_t)0x12345678);			
@@ -620,15 +622,15 @@ DOCTEST_TEST_CASE("Optimization bblock_thunk_removal_pass")
 
 		//Check tracer result before running passes
 		vtil::tracer tracer;
-		auto exp1 = tracer.rtrace_p({ std::prev(block4->end()), vtil::register_desc(registers::ax) });
+		auto exp1 = tracer.rtrace_p({ std::prev(block4->end()), reg_ax });
 		
 		vtil::optimizer::apply_all(block1->owner);
 		vtil::logger::log("After:\n");
 		vtil::debug::dump(block1->owner);	
 
-		//Check tracer result before running passes
+		//Check tracer result after running passes
 		vtil::tracer tracer2;
-		auto exp2 = tracer2.rtrace_p({ std::prev(block1->end()), vtil::register_desc(registers::ax) });			
+		auto exp2 = tracer2.rtrace_p({ std::prev(block1->end()), reg_ax });			
 		
 		CHECK(exp1.get()->equals(*exp2.get()));
 	}


### PR DESCRIPTION
Added a new pass that detects thunk like (I'm open to better naming suggestions) single jump basic_blocks and removes them.
It does that by changing the destination of the previous branch and fixing the prev/next links.

I had to make changes to auxiliaries.cpp as the master branch version made optimization way worse in my case.
The change in variable.cpp is the same as pull request 62 from wallds

Example:
![image](https://user-images.githubusercontent.com/26795431/149333463-9de1eb94-9b27-4046-8b5b-7cd116249c0c.png)
