### PR TITLE
Force x86-64 on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,6 @@
 # Require at least CMake version 3.14.5 or later for FetchContent
 cmake_minimum_required(VERSION 3.14.5)
 
-# Force x86-64 on MacOS (for Apple Silicon)
-if(APPLE)
-    set(CMAKE_OSX_ARCHITECTURES "x86_64")
-endif()
-
 # Define the VTIL project
 project(VTIL-Core)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 # Require at least CMake version 3.14.5 or later for FetchContent
 cmake_minimum_required(VERSION 3.14.5)
 
+# Force x86-64 on MacOS (for Apple Silicon)
+if(APPLE)
+    set(CMAKE_OSX_ARCHITECTURES "x86_64")
+endif()
+
 # Define the VTIL project
 project(VTIL-Core)
 

--- a/README.md
+++ b/README.md
@@ -55,3 +55,6 @@ Then open `build\VTIL-Core.sln`. You can also open this folder in a CMake-compat
 cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build
 ```
+
+**Note:**
+To build on Apple Silicon one needs to use `-DCMAKE_OSX_ARCHITECTURES=x86_64`.


### PR DESCRIPTION
This would allow people to build VTIL on Apple Silicon.
It requires Rosetta 2 and a CMake that supports x86-64 but everything else should be normal.