### PR TITLE
Include <utility> in copy_on_write.hpp

### DIFF
--- a/VTIL-Common/util/copy_on_write.hpp
+++ b/VTIL-Common/util/copy_on_write.hpp
@@ -30,6 +30,7 @@
 #include <functional>
 #include <type_traits>
 #include <atomic>
+#include <utility>
 #include "../io/asserts.hpp"
 #include "object_pool.hpp"
 #include "../util/intrinsics.hpp"


### PR DESCRIPTION
It is required for std::exchange() on GCC. 
Some other compilers include it automatically (maybe for `<atomic>`?)

See: https://en.cppreference.com/w/cpp/utility#Swap
See also this issue: https://github.com/doxygen/doxygen/issues/9312